### PR TITLE
no_std and custom storage support, fallible allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ aligned-vec = { version = "0.6.1", optional = true }
 [features]
 default = ["alloc"]
 alloc = ["dep:aligned-vec"]
+
+[dev-dependencies]
+static_cell = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,8 @@ exclude = [".idea"]
 
 [dependencies]
 derive-where = "1.2.7"
-aligned-vec = "0.6.1"
+aligned-vec = { version = "0.6.1", optional = true }
+
+[features]
+default = ["alloc"]
+alloc = ["dep:aligned-vec"]

--- a/examples/no_alloc.rs
+++ b/examples/no_alloc.rs
@@ -1,0 +1,69 @@
+// cargo run --example no_alloc --no-default-features
+
+use core::mem::MaybeUninit;
+
+use index_arena::Storage;
+use static_cell::StaticCell;
+
+struct SliceStorage<'a> {
+    bytes: &'a mut [MaybeUninit<u8>],
+    current_byte_offset: usize,
+}
+
+impl<'a> SliceStorage<'a> {
+    fn new(bytes: &'a mut [MaybeUninit<u8>]) -> Self {
+        Self {
+            bytes,
+            current_byte_offset: 0,
+        }
+    }
+}
+
+impl<'a> Storage for SliceStorage<'a> {
+    fn alloc_raw(&mut self, len: usize) -> Option<usize> {
+        let old_byte_offset = self.current_byte_offset;
+        let new_byte_offset = self.current_byte_offset + len;
+        if new_byte_offset > self.bytes.len() {
+            None
+        } else {
+            self.current_byte_offset = new_byte_offset;
+            Some(old_byte_offset)
+        }
+    }
+
+    fn current_byte_offset(&self) -> usize {
+        self.current_byte_offset
+    }
+
+    fn as_ptr(&self) -> *const MaybeUninit<u8> {
+        self.bytes.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
+        self.bytes.as_mut_ptr()
+    }
+}
+
+static STATIC_BUFFER: StaticCell<[MaybeUninit<u8>; 128]> = StaticCell::new();
+
+fn main() {
+    let static_buffer = STATIC_BUFFER.init([MaybeUninit::uninit(); 128]);
+    let mut stack_buffer: [MaybeUninit<u8>; 128] = [MaybeUninit::uninit(); 128];
+
+    let mut arena_in_static =
+        index_arena::new_arena_with_storage!(SliceStorage::new(static_buffer));
+    let mut arena_in_stack =
+        index_arena::new_arena_with_storage!(SliceStorage::new(&mut stack_buffer));
+
+    let hello = arena_in_static.alloc_str("Hello, world on static");
+    println!("hello = \"{}\"", &arena_in_static[hello]);
+
+    let hello_again = arena_in_static.try_alloc_str("Hello, world on static");
+    println!("hello_again = {:?}", hello_again);
+
+    let hello = arena_in_stack.alloc_str("Hello, world on stack");
+    println!("hello = \"{}\"", &arena_in_stack[hello]);
+
+    let hello_again = arena_in_stack.try_alloc_str("Hello, world on stack");
+    println!("hello_again = {:?}", hello_again);
+}

--- a/examples/no_alloc.rs
+++ b/examples/no_alloc.rs
@@ -42,6 +42,10 @@ impl<'a> Storage for SliceStorage<'a> {
     fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
         self.bytes.as_mut_ptr()
     }
+
+    fn free_bytes(&self) -> Option<usize> {
+        Some(self.bytes.len() - self.current_byte_offset)
+    }
 }
 
 static STATIC_BUFFER: StaticCell<[MaybeUninit<u8>; 128]> = StaticCell::new();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,10 +381,23 @@ impl<A> Arena<A> {
     }
 
     /// Allocates a new value of type `T` in the arena and returns its `Id`.
-    #[inline]
     pub fn alloc<T>(&mut self, item: T) -> Id<T, A> {
+        self.try_alloc(item).unwrap()
+    }
+
+    pub fn alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Id<[T], A> {
+        self.try_alloc_slice(slice).unwrap()
+    }
+
+    pub fn alloc_str(&mut self, str: &str) -> Id<str, A> {
+        self.try_alloc_str(str).unwrap()
+    }
+
+    /// Try to allocates a new value of type `T` in the arena and returns its `Id`.
+    #[inline]
+    pub fn try_alloc<T>(&mut self, item: T) -> Option<Id<T, A>> {
         // Allocate a new item without initializing it.
-        let id = self.alloc_uninit::<T>();
+        let id = self.alloc_uninit::<T>()?;
 
         // SAFETY: `MaybeUninit::as_mut_ptr` always returns a valid pointer for `ptr::write`.
         unsafe {
@@ -392,49 +405,49 @@ impl<A> Arena<A> {
         }
 
         // SAFETY: we have just initialized the memory associated with `id`.
-        unsafe { Id::new(id.spec.assume_init()) }
+        Some(unsafe { Id::new(id.spec.assume_init()) })
     }
 
     #[inline]
-    pub fn alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Id<[T], A> {
-        let id = self.alloc_slice_uninit(slice.len());
+    pub fn try_alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Option<Id<[T], A>> {
+        let id = self.alloc_slice_uninit(slice.len())?;
         <MaybeUninit<T> as MaybeUninitExt<T>>::clone_from_slice(self.get_mut(id), slice);
-        unsafe { Id::new(id.spec.assume_init()) }
+        Some(unsafe { Id::new(id.spec.assume_init()) })
     }
 
     #[inline]
-    pub fn alloc_str(&mut self, str: &str) -> Id<str, A> {
-        let slice = self.alloc_slice(str.as_bytes());
-        Id::new(unsafe { StrId::new(slice.spec) })
+    pub fn try_alloc_str(&mut self, str: &str) -> Option<Id<str, A>> {
+        let slice = self.try_alloc_slice(str.as_bytes())?;
+        Some(Id::new(unsafe { StrId::new(slice.spec) }))
     }
 
     #[inline]
-    fn alloc_uninit<T>(&mut self) -> Id<MaybeUninit<T>, A> {
+    fn alloc_uninit<T>(&mut self) -> Option<Id<MaybeUninit<T>, A>> {
         assert_const!(align_of::<T>() <= MAX_ALIGN && size_of::<T>() != 0);
 
         // SAFETY: `align_of::<T>` cannot exceed `MAX_ALIGN`.
-        let byte_offset = unsafe { self.alloc_layout(Layout::new::<T>()) };
+        let byte_offset = unsafe { self.alloc_layout(Layout::new::<T>()) }?;
 
         // SAFETY: the memory location at `byte_offset` is properly
         // aligned to hold a value of type `T` and `MaybeUninit`
         // does not require initialization.
-        unsafe { Id::new(SizedId::new(byte_offset)) }
+        Some(unsafe { Id::new(SizedId::new(byte_offset)) })
     }
 
     #[inline]
-    fn alloc_slice_uninit<T>(&mut self, len: usize) -> Id<[MaybeUninit<T>], A> {
+    fn alloc_slice_uninit<T>(&mut self, len: usize) -> Option<Id<[MaybeUninit<T>], A>> {
         assert_const!(align_of::<T>() <= MAX_ALIGN && size_of::<T>() != 0);
 
         let layout = Layout::array::<T>(len).unwrap();
 
         // SAFETY: the alignment of an array is the same as the alignment of
         // its elements and `align_of::<T>` cannot exceed `MAX_ALIGN`.
-        let byte_offset = unsafe { self.alloc_layout(layout) };
+        let byte_offset = unsafe { self.alloc_layout(layout) }?;
 
         // SAFETY: the memory location at `byte_offset` is properly
         // aligned to hold a value of type `[T; len]` and `MaybeUninit`
         // does not require initialization.
-        unsafe { Id::new(SliceId::new(byte_offset, len)) }
+        unsafe { Some(Id::new(SliceId::new(byte_offset, len))) }
     }
 
     /// Allocates uninitialized memory suitable to hold a value with the given layout
@@ -443,7 +456,7 @@ impl<A> Arena<A> {
     /// # Safety
     /// `layout.size()` must not be zero and `layout.align()` must not exceed `MAX_ALIGN`.
     #[inline]
-    unsafe fn alloc_layout(&mut self, layout: Layout) -> usize {
+    unsafe fn alloc_layout(&mut self, layout: Layout) -> Option<usize> {
         // Since the backing storage is aligned to `MAX_ALIGN` and
         // `layout.align() <= MAX_ALIGN`, we only need to ensure that
         // the start of the new allocation is aligned to `layout.align()`.
@@ -456,17 +469,17 @@ impl<A> Arena<A> {
         // `2 * (isize::MAX as usize)`, which is less than `usize::MAX`.
         let padded_size = unsafe { layout.size().unchecked_add(padding) };
 
-        let unaligned_byte_offset = self.alloc_raw(padded_size);
+        let unaligned_byte_offset = self.alloc_raw(padded_size)?;
 
         // SAFETY: `padding < padded_size`, `grow()` didn't panic and length
         // cannot be less than capacity, so this must not overflow.
-        unsafe { unaligned_byte_offset.unchecked_add(padding) }
+        unsafe { Some(unaligned_byte_offset.unchecked_add(padding)) }
     }
 
     /// Allocates `size_in_bytes` uninitialized bytes in the arena and
     /// returns the byte offset of the beginning of the allocation.
     #[inline]
-    fn alloc_raw(&mut self, size_in_bytes: usize) -> usize {
+    fn alloc_raw(&mut self, size_in_bytes: usize) -> Option<usize> {
         self.storage.reserve(size_in_bytes);
 
         let old_len = self.storage.len();
@@ -480,7 +493,7 @@ impl<A> Arena<A> {
             self.storage.set_len(new_len);
         }
 
-        old_len
+        Some(old_len)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@
 //! This leverages the type system to statically assign every identifier to the
 //! arena it belongs to, ensuring safety without incurring runtime overhead.
 //!
-//! Accessing individual elements is achieved via various arena methods, 
+//! Accessing individual elements is achieved via various arena methods,
 //! conceptually similar to indexing a `Vec`.
 //!
 //! ## Heterogeneous
 //!
-//! Supports allocating values of all statically sized, non-ZST types as well slices and string slices. 
-//! This is particularly useful for managing tree-like data structures 
+//! Supports allocating values of all statically sized, non-ZST types as well slices and string slices.
+//! This is particularly useful for managing tree-like data structures
 //! with different node types.
 //!
 //! ## Statically guaranteed safety
@@ -52,16 +52,16 @@
 
 #![allow(private_bounds)]
 
+use aligned_vec::{AVec, ConstAlign};
 use core::alloc::Layout;
+use core::fmt::Debug;
+use core::hash::Hash;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use core::ops::{Index, IndexMut};
 use core::ptr;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::ops::{Index, IndexMut};
-use std::slice::{from_raw_parts, from_raw_parts_mut};
-use std::str::{from_utf8_unchecked, from_utf8_unchecked_mut};
-use aligned_vec::{AVec, ConstAlign};
+use core::slice::{from_raw_parts, from_raw_parts_mut};
+use core::str::{from_utf8_unchecked, from_utf8_unchecked_mut};
 use derive_where::derive_where;
 
 use crate::utils::MaybeUninitExt;
@@ -105,10 +105,14 @@ struct SizedId<T, A> {
 impl<T, A> SizedId<T, A> {
     #[inline]
     unsafe fn new(byte_offset: usize) -> SizedId<T, A> {
-        let byte_offset: u32 = byte_offset.try_into()
+        let byte_offset: u32 = byte_offset
+            .try_into()
             .expect("`byte_offset` must not exceed `u32::MAX`");
 
-        SizedId { byte_offset, _marker: PhantomData }
+        SizedId {
+            byte_offset,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -120,7 +124,10 @@ impl<T, A> SizedId<MaybeUninit<T>, A> {
     /// The caller must ensure the value is fully initialized before calling this method.
     #[inline]
     unsafe fn assume_init(self) -> SizedId<T, A> {
-        SizedId { byte_offset: self.byte_offset, _marker: PhantomData }
+        SizedId {
+            byte_offset: self.byte_offset,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -137,13 +144,17 @@ struct SliceId<T, A> {
 impl<T, A> SliceId<T, A> {
     #[inline]
     unsafe fn new(byte_offset: usize, len: usize) -> SliceId<T, A> {
-        let byte_offset: u32 = byte_offset.try_into()
+        let byte_offset: u32 = byte_offset
+            .try_into()
             .expect("`byte_offset` must not exceed `u32::MAX`");
 
-        let len: u32 = len.try_into()
-            .expect("`len` must not exceed `u32::MAX`");
+        let len: u32 = len.try_into().expect("`len` must not exceed `u32::MAX`");
 
-        SliceId { byte_offset, len, _marker: PhantomData }
+        SliceId {
+            byte_offset,
+            len,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -156,12 +167,16 @@ impl<T, A> SliceId<MaybeUninit<T>, A> {
     /// initialized before calling this method.
     #[inline]
     unsafe fn assume_init(self) -> SliceId<T, A> {
-        SliceId { byte_offset: self.byte_offset, len: self.len, _marker: PhantomData }
+        SliceId {
+            byte_offset: self.byte_offset,
+            len: self.len,
+            _marker: PhantomData,
+        }
     }
 }
 
 /// `Id` specialization for string slices.
-/// 
+///
 /// The underlying slice always represents a valid UTF-8 encoded string.
 /// All the guarantees `Id` makes also apply for this type.
 #[derive_where(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -222,7 +237,9 @@ unsafe impl<T, A> SpecId<A> for T {
 
     #[inline]
     fn get_raw_id(id: Self::Id) -> RawId {
-        RawId { byte_offset: id.byte_offset }
+        RawId {
+            byte_offset: id.byte_offset,
+        }
     }
 }
 
@@ -254,7 +271,9 @@ unsafe impl<T, A> SpecId<A> for [T] {
     }
 
     fn get_raw_id(id: Self::Id) -> RawId {
-        RawId { byte_offset: id.byte_offset }
+        RawId {
+            byte_offset: id.byte_offset,
+        }
     }
 }
 
@@ -274,7 +293,7 @@ unsafe impl<A> SpecId<A> for str {
     fn get_raw_id(id: Self::Id) -> RawId {
         <[u8] as SpecId<A>>::get_raw_id(id.0)
     }
-} 
+}
 
 /// A unique identifier for an object allocated using `Arena`.
 ///
@@ -368,7 +387,9 @@ impl<A> Arena<A> {
         let id = self.alloc_uninit::<T>();
 
         // SAFETY: `MaybeUninit::as_mut_ptr` always returns a valid pointer for `ptr::write`.
-        unsafe { ptr::write(self.get_mut(id).as_mut_ptr(), item); }
+        unsafe {
+            ptr::write(self.get_mut(id).as_mut_ptr(), item);
+        }
 
         // SAFETY: we have just initialized the memory associated with `id`.
         unsafe { Id::new(id.spec.assume_init()) }
@@ -380,7 +401,7 @@ impl<A> Arena<A> {
         <MaybeUninit<T> as MaybeUninitExt<T>>::clone_from_slice(self.get_mut(id), slice);
         unsafe { Id::new(id.spec.assume_init()) }
     }
-    
+
     #[inline]
     pub fn alloc_str(&mut self, str: &str) -> Id<str, A> {
         let slice = self.alloc_slice(str.as_bytes());
@@ -455,7 +476,9 @@ impl<A> Arena<A> {
         let new_len = unsafe { old_len.unchecked_add(size_in_bytes) };
 
         // SAFETY: we have just reserved `additional` bytes.
-        unsafe { self.storage.set_len(new_len); }
+        unsafe {
+            self.storage.set_len(new_len);
+        }
 
         old_len
     }
@@ -516,13 +539,11 @@ macro_rules! new_arena {
         $crate::new_arena!(Default)
     };
 
-    ($name:ident) => {
-        {
-            struct $name;
-            // SAFETY: `$name` is unique for each macro invocation.
-            unsafe { $crate::Arena::<$name>::new() }
-        }
-    };
+    ($name:ident) => {{
+        struct $name;
+        // SAFETY: `$name` is unique for each macro invocation.
+        unsafe { $crate::Arena::<$name>::new() }
+    }};
 }
 
 #[cfg(test)]
@@ -588,7 +609,7 @@ mod test {
         assert_eq!(arena.get(b_id), &"heaven");
         assert_eq!(*arena.get(a_id), 12u16 * 3);
     }
-    
+
     #[test]
     fn arena_alloc_slice() {
         let mut arena = new_arena!();
@@ -606,7 +627,7 @@ mod test {
         arena[id][1] = 3i64;
         assert_eq!(arena[id][1], 3i64);
     }
-    
+
     #[test]
     fn arena_alloc_multiple() {
         let mut arena = new_arena!();
@@ -628,7 +649,7 @@ mod test {
         arena[fruits][0] = "pineapple";
         assert_eq!(arena[fruits][0], "pineapple");
     }
-    
+
     #[test]
     fn arena_alloc_str() {
         let mut arena = new_arena!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,12 @@
 //! assert_eq!(&arena[one].next, &Some(two));
 //! ```
 
+#![no_std]
 #![allow(private_bounds)]
 
+#[cfg(feature = "alloc")]
 use aligned_vec::{AVec, ConstAlign};
+
 use core::alloc::Layout;
 use core::fmt::Debug;
 use core::hash::Hash;
@@ -73,39 +76,6 @@ pub trait Storage {
     fn current_byte_offset(&self) -> usize;
     fn as_ptr(&self) -> *const MaybeUninit<u8>;
     fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8>;
-}
-
-type AVecBytes = AVec<MaybeUninit<u8>, ConstAlign<MAX_ALIGN>>;
-
-impl Storage for AVecBytes {
-    fn alloc_raw(&mut self, len: usize) -> Option<usize> {
-        self.reserve(len);
-
-        let old_len = self.len();
-
-        // SAFETY: `storage.reserve()` didn't panic and length cannot
-        // be less than capacity, so this must not overflow.
-        let new_len = unsafe { old_len.unchecked_add(len) };
-
-        // SAFETY: we have just reserved `additional` bytes.
-        unsafe {
-            self.set_len(new_len);
-        }
-
-        Some(old_len)
-    }
-
-    fn as_ptr(&self) -> *const MaybeUninit<u8> {
-        self.as_ptr()
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
-        self.as_mut_ptr()
-    }
-
-    fn current_byte_offset(&self) -> usize {
-        self.len()
-    }
 }
 
 macro_rules! assert_const {
@@ -396,6 +366,42 @@ pub struct Arena<A, S> {
     _marker: PhantomData<A>,
 }
 
+#[cfg(feature = "alloc")]
+type AVecBytes = AVec<MaybeUninit<u8>, ConstAlign<MAX_ALIGN>>;
+
+#[cfg(feature = "alloc")]
+impl Storage for AVecBytes {
+    fn alloc_raw(&mut self, len: usize) -> Option<usize> {
+        self.reserve(len);
+
+        let old_len = self.len();
+
+        // SAFETY: `storage.reserve()` didn't panic and length cannot
+        // be less than capacity, so this must not overflow.
+        let new_len = unsafe { old_len.unchecked_add(len) };
+
+        // SAFETY: we have just reserved `additional` bytes.
+        unsafe {
+            self.set_len(new_len);
+        }
+
+        Some(old_len)
+    }
+
+    fn as_ptr(&self) -> *const MaybeUninit<u8> {
+        self.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
+        self.as_mut_ptr()
+    }
+
+    fn current_byte_offset(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<A> Arena<A, AVecBytes> {
     /// Creates a new, empty arena.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,14 @@
 //! ## Examples
 //!
 //! ```rust
-//! use index_arena::{Id, new_arena};
+//! use index_arena::{Id, new_arena, Storage};
 //!
-//! struct Even<A> {
-//!     next: Option<Id<Odd<A>, A>>,
+//! struct Even<A, S: Storage> {
+//!     next: Option<Id<Odd<A, S>, A, S>>,
 //! }
 //!
-//! struct Odd<A> {
-//!     next: Option<Id<Even<A>, A>>,
+//! struct Odd<A, S: Storage> {
+//!     next: Option<Id<Even<A, S>, A, S>>,
 //! }
 //!
 //! let mut arena = new_arena!();
@@ -67,6 +67,46 @@ use derive_where::derive_where;
 use crate::utils::MaybeUninitExt;
 
 mod utils;
+
+pub trait Storage {
+    fn alloc_raw(&mut self, len: usize) -> Option<usize>;
+    fn current_byte_offset(&self) -> usize;
+    fn as_ptr(&self) -> *const MaybeUninit<u8>;
+    fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8>;
+}
+
+type AVecBytes = AVec<MaybeUninit<u8>, ConstAlign<MAX_ALIGN>>;
+
+impl Storage for AVecBytes {
+    fn alloc_raw(&mut self, len: usize) -> Option<usize> {
+        self.reserve(len);
+
+        let old_len = self.len();
+
+        // SAFETY: `storage.reserve()` didn't panic and length cannot
+        // be less than capacity, so this must not overflow.
+        let new_len = unsafe { old_len.unchecked_add(len) };
+
+        // SAFETY: we have just reserved `additional` bytes.
+        unsafe {
+            self.set_len(new_len);
+        }
+
+        Some(old_len)
+    }
+
+    fn as_ptr(&self) -> *const MaybeUninit<u8> {
+        self.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
+        self.as_mut_ptr()
+    }
+
+    fn current_byte_offset(&self) -> usize {
+        self.len()
+    }
+}
 
 macro_rules! assert_const {
     ($cond:expr, $($arg:tt)+) => {
@@ -194,21 +234,21 @@ impl<A> StrId<A> {
 ///
 /// # Safety
 /// Implementors must uphold all the guarantees `Id` makes.
-unsafe trait SpecId<A> {
+unsafe trait SpecId<A, S> {
     type Id: Debug + Copy + Clone + Eq + PartialEq + Hash;
 
-    fn get(arena: &Arena<A>, id: Self::Id) -> &Self;
+    fn get(arena: &Arena<A, S>, id: Self::Id) -> &Self;
 
-    fn get_mut(arena: &mut Arena<A>, id: Self::Id) -> &mut Self;
+    fn get_mut(arena: &mut Arena<A, S>, id: Self::Id) -> &mut Self;
 
     fn get_raw_id(id: Self::Id) -> RawId;
 }
 
-unsafe impl<T, A> SpecId<A> for T {
+unsafe impl<T, A, S: Storage> SpecId<A, S> for T {
     type Id = SizedId<T, A>;
 
     #[inline]
-    fn get(arena: &Arena<A>, id: Self::Id) -> &Self {
+    fn get(arena: &Arena<A, S>, id: Self::Id) -> &Self {
         assert_const!(size_of::<T>() != 0 && align_of::<T>() <= MAX_ALIGN);
 
         let byte_offset = id.byte_offset as usize;
@@ -222,7 +262,7 @@ unsafe impl<T, A> SpecId<A> for T {
     }
 
     #[inline]
-    fn get_mut(arena: &mut Arena<A>, id: Self::Id) -> &mut Self {
+    fn get_mut(arena: &mut Arena<A, S>, id: Self::Id) -> &mut Self {
         assert_const!(size_of::<T>() != 0 && align_of::<T>() <= MAX_ALIGN);
 
         let byte_offset = id.byte_offset as usize;
@@ -243,10 +283,10 @@ unsafe impl<T, A> SpecId<A> for T {
     }
 }
 
-unsafe impl<T, A> SpecId<A> for [T] {
+unsafe impl<T, A, S: Storage> SpecId<A, S> for [T] {
     type Id = SliceId<T, A>;
 
-    fn get(arena: &Arena<A>, id: Self::Id) -> &Self {
+    fn get(arena: &Arena<A, S>, id: Self::Id) -> &Self {
         let byte_offset = id.byte_offset as usize;
         let len = id.len as usize;
 
@@ -258,7 +298,7 @@ unsafe impl<T, A> SpecId<A> for [T] {
         unsafe { from_raw_parts(ptr, len) }
     }
 
-    fn get_mut(arena: &mut Arena<A>, id: Self::Id) -> &mut Self {
+    fn get_mut(arena: &mut Arena<A, S>, id: Self::Id) -> &mut Self {
         let byte_offset = id.byte_offset as usize;
         let len = id.len as usize;
 
@@ -277,21 +317,21 @@ unsafe impl<T, A> SpecId<A> for [T] {
     }
 }
 
-unsafe impl<A> SpecId<A> for str {
+unsafe impl<A, S: Storage> SpecId<A, S> for str {
     type Id = StrId<A>;
 
-    fn get(arena: &Arena<A>, id: Self::Id) -> &Self {
-        let bytes = <[u8] as SpecId<A>>::get(arena, id.0);
+    fn get(arena: &Arena<A, S>, id: Self::Id) -> &Self {
+        let bytes = <[u8] as SpecId<A, S>>::get(arena, id.0);
         unsafe { from_utf8_unchecked(bytes) }
     }
 
-    fn get_mut(arena: &mut Arena<A>, id: Self::Id) -> &mut Self {
-        let bytes = <[u8] as SpecId<A>>::get_mut(arena, id.0);
+    fn get_mut(arena: &mut Arena<A, S>, id: Self::Id) -> &mut Self {
+        let bytes = <[u8] as SpecId<A, S>>::get_mut(arena, id.0);
         unsafe { from_utf8_unchecked_mut(bytes) }
     }
 
     fn get_raw_id(id: Self::Id) -> RawId {
-        <[u8] as SpecId<A>>::get_raw_id(id.0)
+        <[u8] as SpecId<A, S>>::get_raw_id(id.0)
     }
 }
 
@@ -307,23 +347,23 @@ unsafe impl<A> SpecId<A> for str {
 /// as the arena itself, meaning it remains valid as long as the arena exists.
 #[derive_where(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-pub struct Id<T: ?Sized + SpecId<A>, A> {
+pub struct Id<T: ?Sized + SpecId<A, S>, A, S> {
     spec: T::Id,
 }
 
-impl<T: ?Sized + SpecId<A>, A> Id<T, A> {
+impl<T: ?Sized + SpecId<A, S>, A, S> Id<T, A, S> {
     #[inline]
-    fn new(spec: T::Id) -> Id<T, A> {
+    fn new(spec: T::Id) -> Id<T, A, S> {
         Id { spec }
     }
 
     #[inline]
-    fn get(self, arena: &Arena<A>) -> &T {
+    fn get(self, arena: &Arena<A, S>) -> &T {
         T::get(arena, self.spec)
     }
 
     #[inline]
-    fn get_mut(self, arena: &mut Arena<A>) -> &mut T {
+    fn get_mut(self, arena: &mut Arena<A, S>) -> &mut T {
         T::get_mut(arena, self.spec)
     }
 
@@ -333,9 +373,9 @@ impl<T: ?Sized + SpecId<A>, A> Id<T, A> {
     }
 }
 
-impl<T: SpecId<A>, A> From<Id<T, A>> for RawId {
+impl<T: SpecId<A, S>, A, S> From<Id<T, A, S>> for RawId {
     #[inline]
-    fn from(id: Id<T, A>) -> Self {
+    fn from(id: Id<T, A, S>) -> Self {
         id.to_raw_id()
     }
 }
@@ -349,53 +389,68 @@ impl<T: SpecId<A>, A> From<Id<T, A>> for RawId {
 /// However, this approach has a downside: the arena does not track individual elements,
 /// effectively providing a form of type erasure. As a result, it is not possible to
 /// implement proper dropping of individual elements like in `id_arena::Arena`.
-#[derive_where(Debug)]
-pub struct Arena<A> {
-    storage: AVec<MaybeUninit<u8>, ConstAlign<MAX_ALIGN>>,
+// #[derive_where(Debug)]
+pub struct Arena<A, S> {
+    storage: S,
+    // storage: AVec<MaybeUninit<u8>, ConstAlign<MAX_ALIGN>>,
     _marker: PhantomData<A>,
 }
 
-impl<A> Arena<A> {
+impl<A> Arena<A, AVecBytes> {
     /// Creates a new, empty arena.
     ///
     /// # Safety
     /// The caller must ensure that the `A` type parameter is only used for this arena.
     #[inline]
-    pub unsafe fn new() -> Arena<A> {
+    pub unsafe fn new() -> Self {
         Arena {
-            storage: AVec::new(0),
+            storage: AVecBytes::new(0),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<A, S: Storage> Arena<A, S> {
+    /// Creates a new, empty arena.
+    ///
+    /// # Safety
+    /// The caller must ensure that the `A` type parameter is only used for this arena.
+    #[inline]
+    pub unsafe fn new_with_storage(storage: S) -> Self {
+        Arena {
+            storage,
             _marker: PhantomData,
         }
     }
 
     /// Returns a shared reference to the arena-allocated object associated with given `Id`.
     #[inline]
-    pub fn get<T: ?Sized + SpecId<A>>(&self, id: Id<T, A>) -> &T {
+    pub fn get<T: ?Sized + SpecId<A, S>>(&self, id: Id<T, A, S>) -> &T {
         id.get(self)
     }
 
     /// Returns a mutable reference to the arena-allocated object associated with given `Id`.
     #[inline]
-    pub fn get_mut<T: ?Sized + SpecId<A>>(&mut self, id: Id<T, A>) -> &mut T {
+    pub fn get_mut<T: ?Sized + SpecId<A, S>>(&mut self, id: Id<T, A, S>) -> &mut T {
         id.get_mut(self)
     }
 
     /// Allocates a new value of type `T` in the arena and returns its `Id`.
-    pub fn alloc<T>(&mut self, item: T) -> Id<T, A> {
+    pub fn alloc<T>(&mut self, item: T) -> Id<T, A, S> {
         self.try_alloc(item).unwrap()
     }
 
-    pub fn alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Id<[T], A> {
+    pub fn alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Id<[T], A, S> {
         self.try_alloc_slice(slice).unwrap()
     }
 
-    pub fn alloc_str(&mut self, str: &str) -> Id<str, A> {
+    pub fn alloc_str(&mut self, str: &str) -> Id<str, A, S> {
         self.try_alloc_str(str).unwrap()
     }
 
     /// Try to allocates a new value of type `T` in the arena and returns its `Id`.
     #[inline]
-    pub fn try_alloc<T>(&mut self, item: T) -> Option<Id<T, A>> {
+    pub fn try_alloc<T>(&mut self, item: T) -> Option<Id<T, A, S>> {
         // Allocate a new item without initializing it.
         let id = self.alloc_uninit::<T>()?;
 
@@ -409,20 +464,20 @@ impl<A> Arena<A> {
     }
 
     #[inline]
-    pub fn try_alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Option<Id<[T], A>> {
+    pub fn try_alloc_slice<T: Clone>(&mut self, slice: &[T]) -> Option<Id<[T], A, S>> {
         let id = self.alloc_slice_uninit(slice.len())?;
         <MaybeUninit<T> as MaybeUninitExt<T>>::clone_from_slice(self.get_mut(id), slice);
         Some(unsafe { Id::new(id.spec.assume_init()) })
     }
 
     #[inline]
-    pub fn try_alloc_str(&mut self, str: &str) -> Option<Id<str, A>> {
+    pub fn try_alloc_str(&mut self, str: &str) -> Option<Id<str, A, S>> {
         let slice = self.try_alloc_slice(str.as_bytes())?;
         Some(Id::new(unsafe { StrId::new(slice.spec) }))
     }
 
     #[inline]
-    fn alloc_uninit<T>(&mut self) -> Option<Id<MaybeUninit<T>, A>> {
+    fn alloc_uninit<T>(&mut self) -> Option<Id<MaybeUninit<T>, A, S>> {
         assert_const!(align_of::<T>() <= MAX_ALIGN && size_of::<T>() != 0);
 
         // SAFETY: `align_of::<T>` cannot exceed `MAX_ALIGN`.
@@ -435,7 +490,7 @@ impl<A> Arena<A> {
     }
 
     #[inline]
-    fn alloc_slice_uninit<T>(&mut self, len: usize) -> Option<Id<[MaybeUninit<T>], A>> {
+    fn alloc_slice_uninit<T>(&mut self, len: usize) -> Option<Id<[MaybeUninit<T>], A, S>> {
         assert_const!(align_of::<T>() <= MAX_ALIGN && size_of::<T>() != 0);
 
         let layout = Layout::array::<T>(len).unwrap();
@@ -461,7 +516,8 @@ impl<A> Arena<A> {
         // `layout.align() <= MAX_ALIGN`, we only need to ensure that
         // the start of the new allocation is aligned to `layout.align()`.
         // SAFETY: `layout.align()` is guaranteed to be a power of two.
-        let padding = unsafe { compute_padding(self.storage.len(), layout.align()) };
+        let padding =
+            unsafe { compute_padding(self.storage.current_byte_offset(), layout.align()) };
 
         // SAFETY: `compute_padding` ensures that `padding < layout.align()`
         // and `Layout` guarantees that both size and alignment do not exceed
@@ -471,7 +527,7 @@ impl<A> Arena<A> {
 
         let unaligned_byte_offset = self.alloc_raw(padded_size)?;
 
-        // SAFETY: `padding < padded_size`, `grow()` didn't panic and length
+        // SAFETY: `padding < padded_size`, `grow()` didn't panic or return and length
         // cannot be less than capacity, so this must not overflow.
         unsafe { Some(unaligned_byte_offset.unchecked_add(padding)) }
     }
@@ -480,20 +536,7 @@ impl<A> Arena<A> {
     /// returns the byte offset of the beginning of the allocation.
     #[inline]
     fn alloc_raw(&mut self, size_in_bytes: usize) -> Option<usize> {
-        self.storage.reserve(size_in_bytes);
-
-        let old_len = self.storage.len();
-
-        // SAFETY: `storage.reserve()` didn't panic and length cannot
-        // be less than capacity, so this must not overflow.
-        let new_len = unsafe { old_len.unchecked_add(size_in_bytes) };
-
-        // SAFETY: we have just reserved `additional` bytes.
-        unsafe {
-            self.storage.set_len(new_len);
-        }
-
-        Some(old_len)
+        self.storage.alloc_raw(size_in_bytes)
     }
 }
 
@@ -530,32 +573,47 @@ const unsafe fn compute_padding(addr: usize, align: usize) -> usize {
     byte_offset
 }
 
-impl<T: ?Sized + SpecId<A>, A> Index<Id<T, A>> for Arena<A> {
+impl<T: ?Sized + SpecId<A, S>, A, S: Storage> Index<Id<T, A, S>> for Arena<A, S> {
     type Output = T;
 
     #[inline]
-    fn index(&self, id: Id<T, A>) -> &Self::Output {
+    fn index(&self, id: Id<T, A, S>) -> &Self::Output {
         self.get(id)
     }
 }
 
-impl<T: ?Sized + SpecId<A>, A> IndexMut<Id<T, A>> for Arena<A> {
+impl<T: ?Sized + SpecId<A, S>, A, S: Storage> IndexMut<Id<T, A, S>> for Arena<A, S> {
     #[inline]
-    fn index_mut(&mut self, id: Id<T, A>) -> &mut Self::Output {
+    fn index_mut(&mut self, id: Id<T, A, S>) -> &mut Self::Output {
         self.get_mut(id)
     }
 }
 
 #[macro_export]
 macro_rules! new_arena {
-    () => {
-        $crate::new_arena!(Default)
-    };
+    () => {{ $crate::new_arena!(Default) }};
 
     ($name:ident) => {{
         struct $name;
         // SAFETY: `$name` is unique for each macro invocation.
-        unsafe { $crate::Arena::<$name>::new() }
+        unsafe { $crate::Arena::<$name, _>::new() }
+    }};
+
+    ($storage:expr, $name:ident) => {{
+        struct $name;
+        // SAFETY: `$name` is unique for each macro invocation.
+        unsafe { $crate::Arena::<$name, _>::with_storage($storage) }
+    }};
+}
+
+#[macro_export]
+macro_rules! new_arena_with_storage {
+    ($storage:expr) => {{ $crate::new_arena_with_storage!($storage, Default) }};
+
+    ($storage:expr, $name:ident) => {{
+        struct $name;
+        // SAFETY: `$name` is unique for each macro invocation.
+        unsafe { $crate::Arena::<$name, _>::new_with_storage($storage) }
     }};
 }
 
@@ -668,5 +726,88 @@ mod test {
         let mut arena = new_arena!();
         let hello = arena.alloc_str("Hello!");
         assert_eq!(&arena[hello], "Hello!");
+    }
+}
+
+#[cfg(test)]
+mod test_array_storage {
+    use super::*;
+
+    struct ArrayStorage<const SIZE: usize> {
+        bytes: [MaybeUninit<u8>; SIZE],
+        current_byte_offset: usize,
+    }
+
+    impl<const SIZE: usize> ArrayStorage<SIZE> {
+        fn new() -> Self {
+            Self {
+                bytes: [MaybeUninit::uninit(); SIZE],
+                current_byte_offset: 0,
+            }
+        }
+    }
+
+    impl<const S: usize> Storage for ArrayStorage<S> {
+        fn alloc_raw(&mut self, len: usize) -> Option<usize> {
+            let old_byte_offset = self.current_byte_offset;
+            let new_byte_offset = self.current_byte_offset + len;
+            if new_byte_offset > self.bytes.len() {
+                None
+            } else {
+                self.current_byte_offset = new_byte_offset;
+                Some(old_byte_offset)
+            }
+        }
+
+        fn current_byte_offset(&self) -> usize {
+            self.current_byte_offset
+        }
+
+        fn as_ptr(&self) -> *const MaybeUninit<u8> {
+            self.bytes.as_ptr()
+        }
+
+        fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
+            self.bytes.as_mut_ptr()
+        }
+    }
+
+    #[test]
+    fn arena_alloc_str() {
+        let mut arena = new_arena_with_storage!(ArrayStorage::<128>::new());
+        let hello = arena.alloc_str("Hello!");
+        assert_eq!(&arena[hello], "Hello!");
+    }
+
+    #[test]
+    fn arena_try_alloc_str() {
+        let mut arena = new_arena_with_storage!(ArrayStorage::<6>::new());
+        let hello = arena.alloc_str("Hello!");
+        assert_eq!(&arena[hello], "Hello!");
+
+        let mut arena = new_arena_with_storage!(ArrayStorage::<5>::new());
+        let hello = arena.try_alloc_str("Hello!");
+        assert!(hello.is_none());
+
+        let mut arena = new_arena_with_storage!(ArrayStorage::<6>::new());
+        let hello = arena.try_alloc_str("Hello!");
+        let again = arena.try_alloc_str("A");
+        assert_eq!(&arena[hello.unwrap()], "Hello!");
+        assert!(again.is_none())
+    }
+
+    #[test]
+    #[should_panic]
+    fn arena_try_alloc_str_fail() {
+        let mut arena = new_arena_with_storage!(ArrayStorage::<5>::new());
+        let _hello = arena.alloc_str("Hello!");
+    }
+
+    #[test]
+    fn arena_alloc_slice() {
+        let mut arena = new_arena_with_storage!(ArrayStorage::<128>::new());
+        let fruits = ["banana", "orange", "apple"];
+        let id = arena.alloc_slice(&fruits);
+        assert_eq!(arena[id][1], "orange");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub trait Storage {
     fn current_byte_offset(&self) -> usize;
     fn as_ptr(&self) -> *const MaybeUninit<u8>;
     fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8>;
+
+    fn free_bytes(&self) -> Option<usize>;
 }
 
 macro_rules! assert_const {
@@ -399,6 +401,10 @@ impl Storage for AVecBytes {
     fn current_byte_offset(&self) -> usize {
         self.len()
     }
+
+    fn free_bytes(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[cfg(feature = "alloc")]
@@ -439,6 +445,10 @@ impl<A, S: Storage> Arena<A, S> {
     #[inline]
     pub fn get_mut<T: ?Sized + SpecId<A, S>>(&mut self, id: Id<T, A, S>) -> &mut T {
         id.get_mut(self)
+    }
+
+    pub fn free_bytes(&self) -> Option<usize> {
+        self.storage.free_bytes()
     }
 
     /// Allocates a new value of type `T` in the arena and returns its `Id`.
@@ -776,6 +786,10 @@ mod test_array_storage {
         fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
             self.bytes.as_mut_ptr()
         }
+
+        fn free_bytes(&self) -> Option<usize> {
+            Some(S - self.current_byte_offset)
+        }
     }
 
     #[test]
@@ -783,6 +797,7 @@ mod test_array_storage {
         let mut arena = new_arena_with_storage!(ArrayStorage::<128>::new());
         let hello = arena.alloc_str("Hello!");
         assert_eq!(&arena[hello], "Hello!");
+        assert_eq!(122, arena.free_bytes().unwrap());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
-use std::mem;
-use std::mem::MaybeUninit;
-use std::ptr::drop_in_place;
+use core::mem;
+use core::mem::MaybeUninit;
+use core::ptr::drop_in_place;
 
 struct Guard<'a, T> {
     slice: &'a mut [MaybeUninit<T>],
@@ -66,7 +66,11 @@ impl<T> MaybeUninitExt<T> for MaybeUninit<T> {
         // unlike copy_from_slice this does not call clone_from_slice on the slice
         // this is because `MaybeUninit<T: Clone>` does not implement Clone.
 
-        assert_eq!(this.len(), src.len(), "destination and source slices have different lengths");
+        assert_eq!(
+            this.len(),
+            src.len(),
+            "destination and source slices have different lengths"
+        );
         // NOTE: We need to explicitly slice them to the same length
         // for bounds checking to be elided, and the optimizer will
         // generate memcpy for simple cases (for example T = u8).
@@ -74,7 +78,10 @@ impl<T> MaybeUninitExt<T> for MaybeUninit<T> {
         let src = &src[..len];
 
         // guard is needed b/c panic might happen during a clone
-        let mut guard = Guard { slice: this, initialized: 0 };
+        let mut guard = Guard {
+            slice: this,
+            initialized: 0,
+        };
 
         for i in 0..len {
             guard.slice[i].write(src[i].clone());


### PR DESCRIPTION
This PR adds support for custom storage using the new `Storage` trait, defaulting to the original `aligned_vec` implementation. Adds fallible allocations. Now the crate is usable in `no_std` environments.

I marked the PR as draft because I don't know if you @yegorvk are interested in merging these features. If you are interested we can discuss to make a more polished work (more docs or tests etc..) otherwise I will close the PR and keep the changes private for my project.